### PR TITLE
sched/fair: Fix idle CPU selection util_fits_cpu logic

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -7582,26 +7582,25 @@ static inline int select_idle_sibling_cstate_aware(struct task_struct *p, int pr
 				if (cpu_isolated(i))
 					continue;
 
-				/* figure out if the task can fit here at all */
 				new_usage = boosted_task_util(p);
-				capacity_orig = capacity_orig_of(i);
-
-				if (new_usage > capacity_orig)
-					goto next;
-
 				util_min = uclamp_eff_value(p, UCLAMP_MIN);
 				util_max = uclamp_eff_value(p, UCLAMP_MAX);
+
+				/* figure out if the task can fit here at all */
+				if (!util_fits_cpu(p, new_usage, util_min, util_max, i))
+					goto next;
 
 				/* if the task fits without changing OPP and we
 				 * intended to use this CPU, just proceed
 				 */
-				if (i == target && util_fits_cpu(p, new_usage, util_min, util_max, i))
+				if (i == target)
 					return target;
 
 				/* otherwise select CPU with shallowest idle state
 				 * to reduce wakeup latency.
 				 */
 				idle_idx = idle_get_state_idx(cpu_rq(i));
+				capacity_orig = capacity_orig_of(i);
 
 				if (idle_idx < best_idle_cstate &&
 					capacity_orig <= best_idle_capacity) {


### PR DESCRIPTION
Prior to this patch, we evaluate whether the new usage fits the CPU's capacity. But with the addition of UCLAMP, we need to consider the clamps of the CPU and the task with util_fits_cpu. This required us to replace the logic comparing the usage towards the capacity.

How this was resolved is greatly flawed. We did not remove the entire capacity comparison logic which should be done entirely by util_fits_cpu. We should actually use util_fits_cpu to decide on whether we should go towards the next sched_group. And that if the new_usage does fit the CPU, we should consider it as the best_idle_cpu if it has sufficient idle_idx.

***

This fixes unoptimal task placement on idle CPUs and should help reduce power consumption.